### PR TITLE
Implement multilingual settings and changelog

### DIFF
--- a/app.js
+++ b/app.js
@@ -3,24 +3,256 @@ class NexiaApp {
         this.currentView = 'editor';
         this.currentPage = 'welcome';
         this.currentTheme = 'light';
+        this.lang = 'ja';
+        this.translations = {
+            ja: {
+                app_name: 'Nexia Beta',
+                tagline: 'Connect. Organize. Achieve.',
+                search_placeholder: '検索...',
+                add_new: '+ 新規',
+                pages: 'ページ',
+                views: '表示',
+                timer: 'タイマー',
+                start: '開始',
+                pause: '一時停止',
+                reset: 'リセット',
+                pomodoro: 'ポモドーロ (25分)',
+                custom: 'カスタム',
+                stopwatch: 'ストップウォッチ',
+                minutes: '分',
+                add_page: '+ ページ追加',
+                table: 'テーブル',
+                kanban: 'カンバン',
+                list: 'リスト',
+                calendar: 'カレンダー',
+                export: 'エクスポート',
+                import: 'インポート',
+                page_settings: '設定',
+                block_heading: '見出し',
+                block_text: 'テキスト',
+                block_task: 'タスク',
+                block_checklist: 'チェックリスト',
+                block_divider: '区切り線',
+                tasks_list: 'タスク一覧',
+                all_priorities: 'すべての優先度',
+                priority_high: '高',
+                priority_medium: '中',
+                priority_low: '低',
+                add_task: '+ タスク追加',
+                table_complete: '完了',
+                table_task: 'タスク名',
+                table_priority: '優先度',
+                table_due: '期限',
+                table_tags: 'タグ',
+                table_actions: '操作',
+                kanban_board: 'カンバンボード',
+                todo: 'Todo',
+                in_progress: '進行中',
+                completed: '完了',
+                list_view: 'リスト表示',
+                settings: '設定',
+                others: 'その他',
+                settings_username: 'ユーザーネーム',
+                settings_language: '言語',
+                settings_theme: 'テーマ',
+                theme_light: 'ライト',
+                theme_dark: 'ダーク',
+                command_placeholder: 'コマンドを入力...',
+                cmd_new_task: '新しいタスク',
+                cmd_new_page: '新しいページ',
+                cmd_export: 'エクスポート',
+                cmd_import: 'インポート',
+                cmd_toggle_theme: 'テーマ切り替え',
+                task_modal_title: 'タスクを編集',
+                task_name: 'タスク名',
+                description: '説明',
+                priority: '優先度',
+                due_date: '期限',
+                tags: 'タグ (カンマ区切り)',
+                subtasks: 'サブタスク (改行区切り)',
+                cancel: 'キャンセル',
+                save: '保存',
+                tags_placeholder: '仕事, 重要',
+                subtasks_placeholder: 'サブタスク1\nサブタスク2',
+                command_new: '新規追加',
+                minutes_placeholder: '分',
+                settings_saved: '設定を保存しました',
+                changelog: '更新履歴',
+                changelog_v1: '初期リリース、多言語対応を追加'
+            },
+            en: {
+                app_name: 'Nexia Beta',
+                tagline: 'Connect. Organize. Achieve.',
+                search_placeholder: 'Search...',
+                add_new: '+ New',
+                pages: 'Pages',
+                views: 'Views',
+                timer: 'Timer',
+                start: 'Start',
+                pause: 'Pause',
+                reset: 'Reset',
+                pomodoro: 'Pomodoro (25m)',
+                custom: 'Custom',
+                stopwatch: 'Stopwatch',
+                minutes: 'min',
+                add_page: '+ Add Page',
+                table: 'Table',
+                kanban: 'Kanban',
+                list: 'List',
+                calendar: 'Calendar',
+                export: 'Export',
+                import: 'Import',
+                page_settings: 'Settings',
+                block_heading: 'Heading',
+                block_text: 'Text',
+                block_task: 'Task',
+                block_checklist: 'Checklist',
+                block_divider: 'Divider',
+                tasks_list: 'Tasks',
+                all_priorities: 'All Priorities',
+                priority_high: 'High',
+                priority_medium: 'Medium',
+                priority_low: 'Low',
+                add_task: '+ Add Task',
+                table_complete: 'Done',
+                table_task: 'Task',
+                table_priority: 'Priority',
+                table_due: 'Due',
+                table_tags: 'Tags',
+                table_actions: 'Actions',
+                kanban_board: 'Kanban Board',
+                todo: 'Todo',
+                in_progress: 'In Progress',
+                completed: 'Completed',
+                list_view: 'List View',
+                settings: 'Settings',
+                others: 'Others',
+                settings_username: 'Username',
+                settings_language: 'Language',
+                settings_theme: 'Theme',
+                theme_light: 'Light',
+                theme_dark: 'Dark',
+                command_placeholder: 'Type a command...',
+                cmd_new_task: 'New Task',
+                cmd_new_page: 'New Page',
+                cmd_export: 'Export',
+                cmd_import: 'Import',
+                cmd_toggle_theme: 'Toggle Theme',
+                task_modal_title: 'Edit Task',
+                task_name: 'Task Name',
+                description: 'Description',
+                priority: 'Priority',
+                due_date: 'Due Date',
+                tags: 'Tags (comma separated)',
+                subtasks: 'Subtasks (one per line)',
+                cancel: 'Cancel',
+                save: 'Save',
+                tags_placeholder: 'work, important',
+                subtasks_placeholder: 'Subtask1\nSubtask2',
+                command_new: 'New',
+                minutes_placeholder: 'min',
+                settings_saved: 'Settings saved',
+                changelog: 'Changelog',
+                changelog_v1: 'Initial release with multi-language support'
+            },
+            ko: {
+                app_name: 'Nexia Beta',
+                tagline: 'Connect. Organize. Achieve.',
+                search_placeholder: '검색...',
+                add_new: '+ 새로 만들기',
+                pages: '페이지',
+                views: '보기',
+                timer: '타이머',
+                start: '시작',
+                pause: '일시 중지',
+                reset: '재설정',
+                pomodoro: '포모도로 (25분)',
+                custom: '사용자 지정',
+                stopwatch: '스톱워치',
+                minutes: '분',
+                add_page: '+ 페이지 추가',
+                table: '테이블',
+                kanban: '칸반',
+                list: '리스트',
+                calendar: '캘린더',
+                export: '내보내기',
+                import: '가져오기',
+                page_settings: '설정',
+                block_heading: '제목',
+                block_text: '텍스트',
+                block_task: '작업',
+                block_checklist: '체크리스트',
+                block_divider: '구분선',
+                tasks_list: '작업 목록',
+                all_priorities: '모든 우선순위',
+                priority_high: '높음',
+                priority_medium: '중간',
+                priority_low: '낮음',
+                add_task: '+ 작업 추가',
+                table_complete: '완료',
+                table_task: '작업',
+                table_priority: '우선순위',
+                table_due: '마감',
+                table_tags: '태그',
+                table_actions: '동작',
+                kanban_board: '칸반 보드',
+                todo: '할 일',
+                in_progress: '진행 중',
+                completed: '완료됨',
+                list_view: '리스트 보기',
+                settings: '설정',
+                others: '기타',
+                settings_username: '사용자 이름',
+                settings_language: '언어',
+                settings_theme: '테마',
+                theme_light: '라이트',
+                theme_dark: '다크',
+                command_placeholder: '명령 입력...',
+                cmd_new_task: '새 작업',
+                cmd_new_page: '새 페이지',
+                cmd_export: '내보내기',
+                cmd_import: '가져오기',
+                cmd_toggle_theme: '테마 전환',
+                task_modal_title: '작업 편집',
+                task_name: '작업명',
+                description: '설명',
+                priority: '우선순위',
+                due_date: '마감일',
+                tags: '태그 (쉼표 구분)',
+                subtasks: '하위 작업 (줄마다 하나)',
+                cancel: '취소',
+                save: '저장',
+                tags_placeholder: '업무, 중요',
+                subtasks_placeholder: '하위작업1\n하위작업2',
+                command_new: '새로 만들기',
+                minutes_placeholder: '분',
+                settings_saved: '설정이 저장되었습니다',
+                changelog: '변경 기록',
+                changelog_v1: '초기 릴리스, 다국어 지원 추가'
+            }
+        };
         this.timer = {
             isRunning: false,
             isPaused: false,
             currentTime: 25 * 60, // 25 minutes in seconds
             interval: null,
-            type: 'pomodoro'
+            type: 'pomodoro',
+            customDuration: 25
         };
         this.data = {
             pages: [],
             tasks: [],
             settings: {
                 theme: 'light',
-                timerDuration: 25
+                timerDuration: 25,
+                language: 'ja',
+                username: 'Guest'
             }
         };
         this.commandPaletteVisible = false;
         this.editingTask = null;
-        
+        this.calendarDate = new Date();
+
         this.init();
     }
 
@@ -28,6 +260,7 @@ class NexiaApp {
         await this.initDatabase();
         await this.loadData();
         this.setupEventListeners();
+        this.applyTranslations();
         this.renderCurrentView();
         this.updateTimer();
     }
@@ -70,13 +303,16 @@ class NexiaApp {
                         priority: 'medium',
                         dueDate: null,
                         tags: ['sample'],
+                        subtasks: [],
                         createdAt: new Date().toISOString(),
                         status: 'todo'
                     }
                 ],
                 settings: {
                     theme: 'light',
-                    timerDuration: 25
+                    timerDuration: 25,
+                    language: 'ja',
+                    username: 'Guest'
                 }
             };
             localStorage.setItem('nexia_data', JSON.stringify(defaultData));
@@ -89,7 +325,9 @@ class NexiaApp {
             if (stored) {
                 this.data = JSON.parse(stored);
                 this.currentTheme = this.data.settings.theme || 'light';
+                this.lang = this.data.settings.language || 'ja';
                 document.documentElement.setAttribute('data-theme', this.currentTheme);
+                document.documentElement.setAttribute('lang', this.lang);
                 this.updateThemeButton();
             }
         } catch (error) {
@@ -130,6 +368,25 @@ class NexiaApp {
         document.getElementById('pauseTimer').addEventListener('click', this.pauseTimer.bind(this));
         document.getElementById('resetTimer').addEventListener('click', this.resetTimer.bind(this));
         document.getElementById('timerType').addEventListener('change', this.changeTimerType.bind(this));
+        document.getElementById('customTimerInput').addEventListener('change', (e) => {
+            const val = parseInt(e.target.value, 10);
+            if (!isNaN(val) && val > 0) {
+                this.timer.customDuration = val;
+                if (this.timer.type === 'custom') {
+                    this.resetTimer();
+                }
+            }
+        });
+
+        // Calendar navigation
+        document.getElementById('prevMonth').addEventListener('click', () => {
+            this.calendarDate.setMonth(this.calendarDate.getMonth() - 1);
+            this.renderCalendarView();
+        });
+        document.getElementById('nextMonth').addEventListener('click', () => {
+            this.calendarDate.setMonth(this.calendarDate.getMonth() + 1);
+            this.renderCalendarView();
+        });
 
         // Editor events
         document.addEventListener('click', (e) => {
@@ -149,6 +406,15 @@ class NexiaApp {
 
         // Export button
         document.getElementById('exportBtn').addEventListener('click', this.exportData.bind(this));
+        document.getElementById('importBtn').addEventListener('click', () => document.getElementById('importInput').click());
+        document.getElementById('importInput').addEventListener('change', (e) => {
+            if (e.target.files[0]) {
+                this.importData(e.target.files[0]);
+                e.target.value = '';
+            }
+        });
+
+        document.getElementById('saveSettingsBtn').addEventListener('click', this.saveSettings.bind(this));
 
         // Keyboard shortcuts
         document.addEventListener('keydown', (e) => {
@@ -215,6 +481,33 @@ class NexiaApp {
         btn.textContent = this.currentTheme === 'light' ? '🌙' : '☀️';
     }
 
+    t(key) {
+        return (this.translations[this.lang] && this.translations[this.lang][key]) || key;
+    }
+
+    applyTranslations() {
+        document.querySelectorAll('[data-i18n]').forEach(el => {
+            el.textContent = this.t(el.dataset.i18n);
+        });
+        document.querySelectorAll('[data-i18n-placeholder]').forEach(el => {
+            el.placeholder = this.t(el.dataset.i18nPlaceholder);
+        });
+        document.documentElement.setAttribute('lang', this.lang);
+        this.updateThemeButton();
+    }
+
+    saveSettings() {
+        this.data.settings.username = document.getElementById('usernameInput').value;
+        this.data.settings.language = document.getElementById('languageSelect').value;
+        this.data.settings.theme = document.getElementById('themeSelect').value;
+        this.currentTheme = this.data.settings.theme;
+        this.lang = this.data.settings.language;
+        document.documentElement.setAttribute('data-theme', this.currentTheme);
+        this.applyTranslations();
+        this.saveData();
+        alert(this.t('settings_saved'));
+    }
+
     // Sidebar Management
     toggleSidebar() {
         const sidebar = document.getElementById('sidebar');
@@ -263,7 +556,14 @@ class NexiaApp {
             case 'calendar':
                 this.renderCalendarView();
                 break;
+            case 'settings':
+                this.renderSettingsView();
+                break;
+            case 'changelog':
+                this.renderChangelogView();
+                break;
         }
+        this.applyTranslations();
     }
 
     // Page Management
@@ -422,15 +722,17 @@ class NexiaApp {
         const form = document.getElementById('taskForm');
 
         if (task) {
-            title.textContent = 'タスクを編集';
+            title.textContent = this.t('task_modal_title');
             document.getElementById('taskTitle').value = task.title || '';
             document.getElementById('taskDescription').value = task.description || '';
             document.getElementById('taskPriority').value = task.priority || 'medium';
             document.getElementById('taskDueDate').value = task.dueDate || '';
             document.getElementById('taskTags').value = task.tags ? task.tags.join(', ') : '';
+            document.getElementById('taskSubtasks').value = task.subtasks ? task.subtasks.map(st => st.title).join('\n') : '';
         } else {
-            title.textContent = '新しいタスク';
+            title.textContent = this.t('cmd_new_task');
             form.reset();
+            document.getElementById('taskSubtasks').value = '';
         }
 
         modal.classList.add('active');
@@ -452,6 +754,7 @@ class NexiaApp {
             priority: document.getElementById('taskPriority').value,
             dueDate: document.getElementById('taskDueDate').value || null,
             tags: document.getElementById('taskTags').value.split(',').map(tag => tag.trim()).filter(tag => tag),
+            subtasks: document.getElementById('taskSubtasks').value.split('\n').map(t => t.trim()).filter(t => t).map(t => ({ id: `sub-${Date.now()}-${Math.random().toString(36).slice(2,5)}`, title: t, completed: false })),
             completed: false,
             status: 'todo'
         };
@@ -492,6 +795,16 @@ class NexiaApp {
         }
     }
 
+    updateTaskStatus(taskId, status) {
+        const task = this.data.tasks.find(t => t.id === taskId);
+        if (task) {
+            task.status = status;
+            task.completed = status === 'completed';
+            this.saveData();
+            this.renderCurrentView();
+        }
+    }
+
     // View Renderers
     renderTableView() {
         const tbody = document.getElementById('tasksTableBody');
@@ -506,6 +819,7 @@ class NexiaApp {
                 <td>
                     <div class="${task.completed ? 'text-decoration: line-through; opacity: 0.6;' : ''}">${task.title}</div>
                     ${task.description ? `<div style="font-size: 12px; color: var(--color-text-secondary); margin-top: 4px;">${task.description}</div>` : ''}
+                    ${task.subtasks && task.subtasks.length > 0 ? `<ul class="subtask-list">${task.subtasks.map(st => `<li>${st.title}</li>`).join('')}</ul>` : ''}
                 </td>
                 <td>
                     <span class="priority-badge priority-badge--${task.priority}">${this.getPriorityText(task.priority)}</span>
@@ -530,11 +844,12 @@ class NexiaApp {
         document.getElementById('todoTasks').innerHTML = todoTasks.map(task => this.renderKanbanTask(task)).join('');
         document.getElementById('inProgressTasks').innerHTML = inProgressTasks.map(task => this.renderKanbanTask(task)).join('');
         document.getElementById('completedTasks').innerHTML = completedTasks.map(task => this.renderKanbanTask(task)).join('');
+        this.addKanbanDragEvents();
     }
 
     renderKanbanTask(task) {
         return `
-            <div class="kanban-task" onclick="app.showTaskModal(app.data.tasks.find(t => t.id === '${task.id}'))">
+            <div class="kanban-task" draggable="true" data-id="${task.id}" onclick="app.showTaskModal(app.data.tasks.find(t => t.id === '${task.id}'))">
                 <div style="font-weight: 500; margin-bottom: 8px;">${task.title}</div>
                 ${task.description ? `<div style="font-size: 12px; color: var(--color-text-secondary); margin-bottom: 8px;">${task.description}</div>` : ''}
                 <div style="display: flex; justify-content: space-between; align-items: center;">
@@ -543,6 +858,29 @@ class NexiaApp {
                 </div>
             </div>
         `;
+    }
+
+    addKanbanDragEvents() {
+        document.querySelectorAll('.kanban-task').forEach(taskEl => {
+            taskEl.addEventListener('dragstart', (e) => {
+                e.dataTransfer.setData('text/plain', taskEl.dataset.id);
+            });
+        });
+
+        document.querySelectorAll('.kanban-tasks').forEach(col => {
+            col.addEventListener('dragover', (e) => {
+                e.preventDefault();
+                col.classList.add('drag-over');
+            });
+            col.addEventListener('dragleave', () => col.classList.remove('drag-over'));
+            col.addEventListener('drop', (e) => {
+                e.preventDefault();
+                const taskId = e.dataTransfer.getData('text/plain');
+                const status = col.dataset.status;
+                this.updateTaskStatus(taskId, status);
+                col.classList.remove('drag-over');
+            });
+        });
     }
 
     renderListView() {
@@ -560,6 +898,7 @@ class NexiaApp {
                         ${task.dueDate ? `<span>期限: ${new Date(task.dueDate).toLocaleDateString('ja-JP')}</span>` : ''}
                         ${task.tags.length > 0 ? `<span>${task.tags.map(tag => `#${tag}`).join(' ')}</span>` : ''}
                     </div>
+                    ${task.subtasks && task.subtasks.length > 0 ? `<ul class="subtask-list">${task.subtasks.map(st => `<li>${st.title}</li>`).join('')}</ul>` : ''}
                 </div>
             </div>
         `).join('');
@@ -567,13 +906,12 @@ class NexiaApp {
 
     renderCalendarView() {
         const now = new Date();
-        const year = now.getFullYear();
-        const month = now.getMonth();
+        const year = this.calendarDate.getFullYear();
+        const month = this.calendarDate.getMonth();
         
         document.getElementById('calendarMonth').textContent = `${year}年${month + 1}月`;
         
         const firstDay = new Date(year, month, 1);
-        const lastDay = new Date(year, month + 1, 0);
         const startDate = new Date(firstDay);
         startDate.setDate(startDate.getDate() - firstDay.getDay());
         
@@ -612,6 +950,16 @@ class NexiaApp {
         grid.innerHTML = html;
     }
 
+    renderSettingsView() {
+        document.getElementById('usernameInput').value = this.data.settings.username || '';
+        document.getElementById('languageSelect').value = this.data.settings.language || 'ja';
+        document.getElementById('themeSelect').value = this.data.settings.theme || 'light';
+    }
+
+    renderChangelogView() {
+        // nothing dynamic for now
+    }
+
     getFilteredTasks() {
         const priorityFilter = document.getElementById('filterPriority').value;
         let tasks = [...this.data.tasks];
@@ -625,10 +973,10 @@ class NexiaApp {
 
     getPriorityText(priority) {
         switch (priority) {
-            case 'high': return '高';
-            case 'medium': return '中';
-            case 'low': return '低';
-            default: return '中';
+            case 'high': return this.t('priority_high');
+            case 'medium': return this.t('priority_medium');
+            case 'low': return this.t('priority_low');
+            default: return this.t('priority_medium');
         }
     }
 
@@ -677,7 +1025,7 @@ class NexiaApp {
         } else if (type === 'stopwatch') {
             this.timer.currentTime = 0;
         } else {
-            this.timer.currentTime = 25 * 60; // Default to 25 minutes
+            this.timer.currentTime = (this.timer.customDuration || 25) * 60;
         }
         
         this.updateTimer();
@@ -687,6 +1035,11 @@ class NexiaApp {
     changeTimerType() {
         const type = document.getElementById('timerType').value;
         this.timer.type = type;
+        const input = document.getElementById('customTimerInput');
+        input.style.display = type === 'custom' ? 'block' : 'none';
+        if (type === 'custom') {
+            input.value = this.timer.customDuration;
+        }
         this.resetTimer();
     }
 
@@ -824,6 +1177,9 @@ class NexiaApp {
             case 'export':
                 this.exportData();
                 break;
+            case 'import':
+                document.getElementById('importInput').click();
+                break;
             case 'toggle-theme':
                 this.toggleTheme();
                 break;
@@ -861,6 +1217,29 @@ class NexiaApp {
         URL.revokeObjectURL(url);
     }
 
+    importData(file) {
+        const reader = new FileReader();
+        reader.onload = (e) => {
+            try {
+                const parsed = JSON.parse(e.target.result);
+                if (parsed.pages && parsed.tasks) {
+                    this.data.pages = parsed.pages;
+                    this.data.tasks = parsed.tasks;
+                    this.data.settings = parsed.settings || this.data.settings;
+                    this.saveData();
+                    this.renderPagesList();
+                    this.renderCurrentView();
+                    alert('データをインポートしました');
+                } else {
+                    alert('無効なデータ形式です');
+                }
+            } catch (err) {
+                alert('インポートに失敗しました');
+            }
+        };
+        reader.readAsText(file);
+    }
+
     // Initialize app
     async start() {
         // Request notification permission
@@ -870,6 +1249,7 @@ class NexiaApp {
         
         this.renderPagesList();
         this.switchView('editor');
+        this.changeTimerType();
     }
 }
 

--- a/index.html
+++ b/index.html
@@ -18,13 +18,13 @@
                 </svg>
             </button>
             <div class="header__logo">
-                <h1>Nexia Beta</h1>
-                <span class="header__tagline">Connect. Organize. Achieve.</span>
+<h1 data-i18n="app_name">Nexia Beta</h1>
+<span class="header__tagline" data-i18n="tagline">Connect. Organize. Achieve.</span>
             </div>
         </div>
         <div class="header__center">
             <div class="search-bar">
-                <input type="text" id="searchInput" placeholder="検索..." class="form-control">
+<input type="text" id="searchInput" class="form-control" data-i18n-placeholder="search_placeholder">
                 <svg class="search-icon" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
                     <circle cx="11" cy="11" r="8"></circle>
                     <path d="M21 21l-4.35-4.35"></path>
@@ -33,7 +33,7 @@
         </div>
         <div class="header__right">
             <button class="btn--secondary btn--sm" id="themeToggle">🌙</button>
-            <button class="btn--primary btn--sm" id="addButton">+ 新規</button>
+<button class="btn--primary btn--sm" id="addButton" data-i18n="add_new">+ 新規</button>
         </div>
     </header>
 
@@ -43,48 +43,60 @@
         <aside class="sidebar" id="sidebar">
             <nav class="sidebar__nav">
                 <div class="sidebar__section">
-                    <h3 class="sidebar__title">ページ</h3>
+                    <h3 class="sidebar__title" data-i18n="pages">ページ</h3>
                     <ul class="sidebar__list" id="pagesList">
                         <li class="sidebar__item sidebar__item--active">
                             <a href="#" data-page="welcome">📝 ようこそ</a>
                         </li>
                     </ul>
-                    <button class="btn--outline btn--sm sidebar__add-btn" id="addPageBtn">+ ページ追加</button>
+                    <button class="btn--outline btn--sm sidebar__add-btn" id="addPageBtn" data-i18n="add_page">+ ページ追加</button>
                 </div>
                 
                 <div class="sidebar__section">
-                    <h3 class="sidebar__title">表示</h3>
+                    <h3 class="sidebar__title" data-i18n="views">表示</h3>
                     <ul class="sidebar__list">
                         <li class="sidebar__item">
-                            <button class="view-toggle" data-view="table">📊 テーブル</button>
+                            <button class="view-toggle" data-view="table" data-i18n="table">📊 テーブル</button>
                         </li>
                         <li class="sidebar__item">
-                            <button class="view-toggle" data-view="kanban">📋 カンバン</button>
+                            <button class="view-toggle" data-view="kanban" data-i18n="kanban">📋 カンバン</button>
                         </li>
                         <li class="sidebar__item">
-                            <button class="view-toggle" data-view="list">📄 リスト</button>
+                            <button class="view-toggle" data-view="list" data-i18n="list">📄 リスト</button>
                         </li>
                         <li class="sidebar__item">
-                            <button class="view-toggle" data-view="calendar">📅 カレンダー</button>
+                            <button class="view-toggle" data-view="calendar" data-i18n="calendar">📅 カレンダー</button>
                         </li>
                     </ul>
                 </div>
 
                 <div class="sidebar__section">
-                    <h3 class="sidebar__title">タイマー</h3>
+                    <h3 class="sidebar__title" data-i18n="timer">タイマー</h3>
                     <div class="timer-widget">
                         <div class="timer-display" id="timerDisplay">25:00</div>
                         <div class="timer-controls">
-                            <button class="btn--sm btn--primary" id="startTimer">開始</button>
-                            <button class="btn--sm btn--secondary" id="pauseTimer">一時停止</button>
-                            <button class="btn--sm btn--outline" id="resetTimer">リセット</button>
+                            <button class="btn--sm btn--primary" id="startTimer" data-i18n="start">開始</button>
+                            <button class="btn--sm btn--secondary" id="pauseTimer" data-i18n="pause">一時停止</button>
+                            <button class="btn--sm btn--outline" id="resetTimer" data-i18n="reset">リセット</button>
                         </div>
                         <select class="form-control timer-select" id="timerType">
-                            <option value="pomodoro">ポモドーロ (25分)</option>
-                            <option value="custom">カスタム</option>
-                            <option value="stopwatch">ストップウォッチ</option>
+                            <option value="pomodoro" data-i18n="pomodoro">ポモドーロ (25分)</option>
+                            <option value="custom" data-i18n="custom">カスタム</option>
+                            <option value="stopwatch" data-i18n="stopwatch">ストップウォッチ</option>
                         </select>
+                        <input type="number" class="form-control timer-custom" id="customTimerInput" min="1" value="25" data-i18n-placeholder="minutes" style="display:none; margin-top:8px;">
                     </div>
+                </div>
+                <div class="sidebar__section">
+                    <h3 class="sidebar__title" data-i18n="others">その他</h3>
+                    <ul class="sidebar__list">
+                        <li class="sidebar__item">
+                            <button class="view-toggle" data-view="settings" data-i18n="settings">⚙️ 設定</button>
+                        </li>
+                        <li class="sidebar__item">
+                            <button class="view-toggle" data-view="changelog" data-i18n="changelog">🕑 更新履歴</button>
+                        </li>
+                    </ul>
                 </div>
             </nav>
         </aside>
@@ -96,45 +108,47 @@
                 <div class="page-header">
                     <h2 id="pageTitle">ページタイトル</h2>
                     <div class="page-actions">
-                        <button class="btn--outline btn--sm" id="exportBtn">エクスポート</button>
-                        <button class="btn--secondary btn--sm" id="pageSettingsBtn">設定</button>
+                        <button class="btn--outline btn--sm" id="exportBtn" data-i18n="export">エクスポート</button>
+                        <button class="btn--outline btn--sm" id="importBtn" data-i18n="import">インポート</button>
+                        <input type="file" id="importInput" accept="application/json" style="display:none">
+                        <button class="btn--secondary btn--sm" id="pageSettingsBtn" data-i18n="page_settings">設定</button>
                     </div>
                 </div>
                 <div class="editor-container" id="editorContainer">
                     <!-- Dynamic blocks will be inserted here -->
                 </div>
                 <div class="add-block-menu" id="addBlockMenu">
-                    <button class="add-block-btn" data-type="heading">📝 見出し</button>
-                    <button class="add-block-btn" data-type="text">📄 テキスト</button>
-                    <button class="add-block-btn" data-type="task">✅ タスク</button>
-                    <button class="add-block-btn" data-type="checklist">☑️ チェックリスト</button>
-                    <button class="add-block-btn" data-type="divider">➖ 区切り線</button>
+                    <button class="add-block-btn" data-type="heading" data-i18n="block_heading">📝 見出し</button>
+                    <button class="add-block-btn" data-type="text" data-i18n="block_text">📄 テキスト</button>
+                    <button class="add-block-btn" data-type="task" data-i18n="block_task">✅ タスク</button>
+                    <button class="add-block-btn" data-type="checklist" data-i18n="block_checklist">☑️ チェックリスト</button>
+                    <button class="add-block-btn" data-type="divider" data-i18n="block_divider">➖ 区切り線</button>
                 </div>
             </div>
 
             <div class="content-view hidden" id="tableView">
                 <div class="view-header">
-                    <h2>タスク一覧</h2>
+                    <h2 data-i18n="tasks_list">タスク一覧</h2>
                     <div class="view-controls">
                         <select class="form-control" id="filterPriority">
-                            <option value="">すべての優先度</option>
-                            <option value="high">高</option>
-                            <option value="medium">中</option>
-                            <option value="low">低</option>
+                            <option value="" data-i18n="all_priorities">すべての優先度</option>
+                            <option value="high" data-i18n="priority_high">高</option>
+                            <option value="medium" data-i18n="priority_medium">中</option>
+                            <option value="low" data-i18n="priority_low">低</option>
                         </select>
-                        <button class="btn--primary btn--sm" id="addTaskBtn">+ タスク追加</button>
+                        <button class="btn--primary btn--sm" id="addTaskBtn" data-i18n="add_task">+ タスク追加</button>
                     </div>
                 </div>
                 <div class="table-container">
                     <table class="tasks-table">
                         <thead>
                             <tr>
-                                <th>完了</th>
-                                <th>タスク名</th>
-                                <th>優先度</th>
-                                <th>期限</th>
-                                <th>タグ</th>
-                                <th>操作</th>
+                                <th data-i18n="table_complete">完了</th>
+                                <th data-i18n="table_task">タスク名</th>
+                                <th data-i18n="table_priority">優先度</th>
+                                <th data-i18n="table_due">期限</th>
+                                <th data-i18n="table_tags">タグ</th>
+                                <th data-i18n="table_actions">操作</th>
                             </tr>
                         </thead>
                         <tbody id="tasksTableBody">
@@ -146,27 +160,27 @@
 
             <div class="content-view hidden" id="kanbanView">
                 <div class="view-header">
-                    <h2>カンバンボード</h2>
+                    <h2 data-i18n="kanban_board">カンバンボード</h2>
                 </div>
                 <div class="kanban-board">
                     <div class="kanban-column">
-                        <h3>Todo</h3>
-                        <div class="kanban-tasks" id="todoTasks"></div>
+                        <h3 data-i18n="todo">Todo</h3>
+                        <div class="kanban-tasks" id="todoTasks" data-status="todo"></div>
                     </div>
                     <div class="kanban-column">
-                        <h3>進行中</h3>
-                        <div class="kanban-tasks" id="inProgressTasks"></div>
+                        <h3 data-i18n="in_progress">進行中</h3>
+                        <div class="kanban-tasks" id="inProgressTasks" data-status="in-progress"></div>
                     </div>
                     <div class="kanban-column">
-                        <h3>完了</h3>
-                        <div class="kanban-tasks" id="completedTasks"></div>
+                        <h3 data-i18n="completed">完了</h3>
+                        <div class="kanban-tasks" id="completedTasks" data-status="completed"></div>
                     </div>
                 </div>
             </div>
 
             <div class="content-view hidden" id="listView">
                 <div class="view-header">
-                    <h2>リスト表示</h2>
+                    <h2 data-i18n="list_view">リスト表示</h2>
                 </div>
                 <div class="tasks-list" id="tasksList">
                     <!-- Tasks will be populated here -->
@@ -175,7 +189,7 @@
 
             <div class="content-view hidden" id="calendarView">
                 <div class="view-header">
-                    <h2>カレンダー</h2>
+                    <h2 data-i18n="calendar">カレンダー</h2>
                 </div>
                 <div class="calendar-container">
                     <div class="calendar-header">
@@ -188,6 +202,44 @@
                     </div>
                 </div>
             </div>
+
+            <div class="content-view hidden" id="settingsView">
+                <div class="view-header">
+                    <h2 data-i18n="settings">設定</h2>
+                </div>
+                <div class="settings-form">
+                    <div class="form-group">
+                        <label class="form-label" data-i18n="settings_username">ユーザーネーム</label>
+                        <input type="text" class="form-control" id="usernameInput">
+                    </div>
+                    <div class="form-group">
+                        <label class="form-label" data-i18n="settings_language">言語</label>
+                        <select class="form-control" id="languageSelect">
+                            <option value="ja">日本語</option>
+                            <option value="en">English</option>
+                            <option value="ko">한국어</option>
+                        </select>
+                    </div>
+                    <div class="form-group">
+                        <label class="form-label" data-i18n="settings_theme">テーマ</label>
+                        <select class="form-control" id="themeSelect">
+                            <option value="light" data-i18n="theme_light">ライト</option>
+                            <option value="dark" data-i18n="theme_dark">ダーク</option>
+                        </select>
+                    </div>
+                    <button class="btn--primary" id="saveSettingsBtn" data-i18n="save">保存</button>
+                </div>
+            </div>
+
+            <div class="content-view hidden" id="changelogView">
+                <div class="view-header">
+                    <h2 data-i18n="changelog">更新履歴</h2>
+                </div>
+                <div class="changelog-content">
+                    <h3>v1.0.0-beta</h3>
+                    <p data-i18n="changelog_v1">初期リリース、多言語対応を追加</p>
+                </div>
+            </div>
         </main>
     </div>
 
@@ -195,38 +247,42 @@
     <div class="modal" id="taskModal">
         <div class="modal__content">
             <div class="modal__header">
-                <h3 id="taskModalTitle">タスクを編集</h3>
+                <h3 id="taskModalTitle" data-i18n="task_modal_title">タスクを編集</h3>
                 <button class="modal__close" id="closeTaskModal">×</button>
             </div>
             <form class="modal__body" id="taskForm">
                 <div class="form-group">
-                    <label class="form-label">タスク名</label>
+                    <label class="form-label" data-i18n="task_name">タスク名</label>
                     <input type="text" class="form-control" id="taskTitle" required>
                 </div>
                 <div class="form-group">
-                    <label class="form-label">説明</label>
+                    <label class="form-label" data-i18n="description">説明</label>
                     <textarea class="form-control" id="taskDescription" rows="3"></textarea>
                 </div>
                 <div class="form-group">
-                    <label class="form-label">優先度</label>
+                    <label class="form-label" data-i18n="priority">優先度</label>
                     <select class="form-control" id="taskPriority">
-                        <option value="low">低</option>
-                        <option value="medium">中</option>
-                        <option value="high">高</option>
+                        <option value="low" data-i18n="priority_low">低</option>
+                        <option value="medium" data-i18n="priority_medium">中</option>
+                        <option value="high" data-i18n="priority_high">高</option>
                     </select>
                 </div>
                 <div class="form-group">
-                    <label class="form-label">期限</label>
+                    <label class="form-label" data-i18n="due_date">期限</label>
                     <input type="date" class="form-control" id="taskDueDate">
                 </div>
                 <div class="form-group">
-                    <label class="form-label">タグ (カンマ区切り)</label>
-                    <input type="text" class="form-control" id="taskTags" placeholder="仕事, 重要">
+                    <label class="form-label" data-i18n="tags">タグ (カンマ区切り)</label>
+                    <input type="text" class="form-control" id="taskTags" data-i18n-placeholder="tags_placeholder" placeholder="仕事, 重要">
+                </div>
+                <div class="form-group">
+                    <label class="form-label" data-i18n="subtasks">サブタスク (改行区切り)</label>
+                    <textarea class="form-control" id="taskSubtasks" rows="3" data-i18n-placeholder="subtasks_placeholder" placeholder="サブタスク1&#10;サブタスク2"></textarea>
                 </div>
             </form>
             <div class="modal__footer">
-                <button class="btn--outline" id="cancelTask">キャンセル</button>
-                <button class="btn--primary" id="saveTask">保存</button>
+                <button class="btn--outline" id="cancelTask" data-i18n="cancel">キャンセル</button>
+                <button class="btn--primary" id="saveTask" data-i18n="save">保存</button>
             </div>
         </div>
     </div>
@@ -234,12 +290,13 @@
     <!-- Command Palette -->
     <div class="command-palette hidden" id="commandPalette">
         <div class="command-palette__content">
-            <input type="text" class="command-palette__input" id="commandInput" placeholder="コマンドを入力...">
+            <input type="text" class="command-palette__input" id="commandInput" data-i18n-placeholder="command_placeholder" placeholder="コマンドを入力...">
             <div class="command-palette__results" id="commandResults">
-                <div class="command-item" data-command="new-task">新しいタスク</div>
-                <div class="command-item" data-command="new-page">新しいページ</div>
-                <div class="command-item" data-command="export">エクスポート</div>
-                <div class="command-item" data-command="toggle-theme">テーマ切り替え</div>
+                <div class="command-item" data-command="new-task" data-i18n="cmd_new_task">新しいタスク</div>
+                <div class="command-item" data-command="new-page" data-i18n="cmd_new_page">新しいページ</div>
+                <div class="command-item" data-command="export" data-i18n="cmd_export">エクスポート</div>
+                <div class="command-item" data-command="import" data-i18n="cmd_import">インポート</div>
+                <div class="command-item" data-command="toggle-theme" data-i18n="cmd_toggle_theme">テーマ切り替え</div>
             </div>
         </div>
     </div>

--- a/style.css
+++ b/style.css
@@ -1105,6 +1105,10 @@ p {
   margin-top: var(--space-12);
 }
 
+.timer-custom {
+  margin-top: var(--space-8);
+}
+
 /* Main Content */
 .main-content {
   flex: 1;
@@ -1352,6 +1356,11 @@ p {
   display: flex;
   flex-direction: column;
   gap: var(--space-12);
+  min-height: 50px;
+}
+
+.kanban-tasks.drag-over {
+  background: var(--color-secondary);
 }
 
 .kanban-task {
@@ -1420,6 +1429,25 @@ p {
   gap: var(--space-12);
   font-size: var(--font-size-sm);
   color: var(--color-text-secondary);
+}
+
+.subtask-list {
+  margin-top: var(--space-4);
+  padding-left: var(--space-16);
+  font-size: var(--font-size-sm);
+  color: var(--color-text-secondary);
+}
+
+.settings-form {
+  max-width: 400px;
+  padding: var(--space-16);
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-12);
+}
+
+.changelog-content {
+  padding: var(--space-16);
 }
 
 /* Calendar View */


### PR DESCRIPTION
## Summary
- added settings and changelog views with sidebar links
- implemented translation system for Japanese, English and Korean
- provided language, theme and username options in settings
- updated existing UI to use i18n keys

## Testing
- `node --check app.js`


------
https://chatgpt.com/codex/tasks/task_e_68468dcfe2d8832498256cc892e7e143