### PR TITLE
Add time tracking

### DIFF
--- a/index.html
+++ b/index.html
@@ -151,6 +151,7 @@
                                 <th data-i18n="table_priority">優先度</th>
                                 <th data-i18n="table_due">期限</th>
                                 <th data-i18n="table_tags">タグ</th>
+                                <th data-i18n="table_time">時間</th>
                                 <th data-i18n="table_actions">操作</th>
                             </tr>
                         </thead>


### PR DESCRIPTION
## Summary
- add Time column in task table
- translate strings for tracking and time
- store timeSpent per task
- implement task tracking timer
- show time tracking controls in table and list views

## Testing
- `node run_nexia_tests.js` *(fails: Cannot find module 'puppeteer')*

------
https://chatgpt.com/codex/tasks/task_e_6846cf887194832481dce69eefad6a9c