### PR TITLE
Implement clear design theme

### DIFF
--- a/app.js
+++ b/app.js
@@ -60,6 +60,7 @@ class NexiaApp {
                 settings_theme: 'テーマ',
                 theme_light: 'ライト',
                 theme_dark: 'ダーク',
+                theme_clear: 'クリアデザイン',
                 command_placeholder: 'コマンドを入力...',
                 cmd_new_task: '新しいタスク',
                 cmd_new_page: '新しいページ',
@@ -81,6 +82,7 @@ class NexiaApp {
                 minutes_placeholder: '分',
                 settings_saved: '設定を保存しました',
                 changelog: '更新履歴',
+                changelog_v101: 'クリアデザイン (iOS/Vision OS風) を追加',
                 changelog_v1: '初期リリース、多言語対応を追加',
                 recurrence_type: '繰り返しタイプ',
                 recurrence_none: 'なし',
@@ -154,6 +156,7 @@ class NexiaApp {
                 settings_theme: 'Theme',
                 theme_light: 'Light',
                 theme_dark: 'Dark',
+                theme_clear: 'Clear',
                 command_placeholder: 'Type a command...',
                 cmd_new_task: 'New Task',
                 cmd_new_page: 'New Page',
@@ -175,6 +178,7 @@ class NexiaApp {
                 minutes_placeholder: 'min',
                 settings_saved: 'Settings saved',
                 changelog: 'Changelog',
+                changelog_v101: 'Added clear iOS/Vision OS-style design option',
                 changelog_v1: 'Initial release with multi-language support',
                 recurrence_type: 'Recurrence Type',
                 recurrence_none: 'None',
@@ -248,6 +252,7 @@ class NexiaApp {
                 settings_theme: '테마',
                 theme_light: '라이트',
                 theme_dark: '다크',
+                theme_clear: '클리어',
                 command_placeholder: '명령 입력...',
                 cmd_new_task: '새 작업',
                 cmd_new_page: '새 페이지',
@@ -269,6 +274,7 @@ class NexiaApp {
                 minutes_placeholder: '분',
                 settings_saved: '설정이 저장되었습니다',
                 changelog: '변경 기록',
+                changelog_v101: 'iOS/Vision OS 스타일 클리어 디자인 옵션 추가',
                 changelog_v1: '초기 릴리스, 다국어 지원 추가',
                 recurrence_type: '반복 유형',
                 recurrence_none: '없음',
@@ -583,7 +589,9 @@ class NexiaApp {
 
     // Theme Management
     toggleTheme() {
-        this.currentTheme = this.currentTheme === 'light' ? 'dark' : 'light';
+        const themes = ['light', 'dark', 'clear'];
+        const idx = themes.indexOf(this.currentTheme);
+        this.currentTheme = themes[(idx + 1) % themes.length];
         document.documentElement.setAttribute('data-theme', this.currentTheme);
         this.data.settings.theme = this.currentTheme;
         this.updateThemeButton();
@@ -592,7 +600,8 @@ class NexiaApp {
 
     updateThemeButton() {
         const btn = document.getElementById('themeToggle');
-        btn.textContent = this.currentTheme === 'light' ? '🌙' : '☀️';
+        const icons = { light: '🌙', dark: '☀️', clear: '🧊' };
+        btn.textContent = icons[this.currentTheme] || '🌙';
     }
 
     t(key) {
@@ -1499,7 +1508,7 @@ class NexiaApp {
         const data = {
             ...this.data,
             exportedAt: new Date().toISOString(),
-            version: '1.0.0'
+            version: '1.0.1-beta'
         };
         
         const blob = new Blob([JSON.stringify(data, null, 2)], { type: 'application/json' });

--- a/index.html
+++ b/index.html
@@ -229,6 +229,7 @@
                         <select class="form-control" id="themeSelect">
                             <option value="light" data-i18n="theme_light">ライト</option>
                             <option value="dark" data-i18n="theme_dark">ダーク</option>
+                            <option value="clear" data-i18n="theme_clear">クリアデザイン</option>
                         </select>
                     </div>
                     <button class="btn--primary" id="saveSettingsBtn" data-i18n="save">保存</button>
@@ -240,6 +241,8 @@
                     <h2 data-i18n="changelog">更新履歴</h2>
                 </div>
                 <div class="changelog-content">
+                    <h3>v1.0.1-beta</h3>
+                    <p data-i18n="changelog_v101">クリアデザインオプションを追加</p>
                     <h3>v1.0.0-beta</h3>
                     <p data-i18n="changelog_v1">初期リリース、多言語対応を追加</p>
                 </div>

--- a/style.css
+++ b/style.css
@@ -459,11 +459,13 @@ select.form-control {
   border: 1px solid var(--color-card-border);
   box-shadow: var(--shadow-sm);
   overflow: hidden;
-  transition: box-shadow var(--duration-normal) var(--ease-standard);
+  transition: box-shadow var(--duration-normal) var(--ease-standard),
+    transform var(--duration-normal) var(--ease-standard);
 }
 
 .card:hover {
   box-shadow: var(--shadow-md);
+  transform: translateY(-2px);
 }
 
 .card__body {
@@ -787,6 +789,64 @@ select.form-control {
   --color-card-border-inner: rgba(255, 255, 255, 0.05);
   --color-sidebar: #252525;
   --color-header: #2d2d2d;
+}
+
+[data-theme="clear"] {
+  --color-background: rgba(255, 255, 255, 0.6);
+  --color-surface: rgba(255, 255, 255, 0.3);
+  --color-text: #2c2c2c;
+  --color-text-secondary: #6b6b6b;
+  --color-primary: #ff7849;
+  --color-primary-hover: #ff8659;
+  --color-primary-active: #ff6a39;
+  --color-secondary: rgba(255, 120, 73, 0.2);
+  --color-secondary-hover: rgba(255, 120, 73, 0.25);
+  --color-secondary-active: rgba(255, 120, 73, 0.3);
+  --color-border: rgba(44, 44, 44, 0.2);
+  --color-btn-primary-text: #1a1a1a;
+  --color-card-border: rgba(44, 44, 44, 0.15);
+  --color-card-border-inner: rgba(44, 44, 44, 0.1);
+  --color-sidebar: rgba(255, 255, 255, 0.15);
+  --color-header: rgba(255, 255, 255, 0.15);
+  --frost-blur: 20px;
+}
+
+[data-theme="clear"] .header,
+[data-theme="clear"] .sidebar,
+[data-theme="clear"] .modal__content,
+[data-theme="clear"] .card,
+[data-theme="clear"] .timer-widget {
+  backdrop-filter: blur(var(--frost-blur));
+  box-shadow: var(--shadow-lg);
+  background-color: var(--color-surface);
+  animation: fadeInUp var(--duration-normal) var(--ease-standard);
+}
+
+[data-theme="clear"] .header {
+  border-bottom: 1px solid var(--color-border);
+}
+
+[data-theme="clear"] .sidebar {
+  border-right: 1px solid var(--color-border);
+}
+
+[data-theme="clear"] .card:hover {
+  transform: translateY(-2px) scale(1.02);
+}
+
+[data-theme="clear"] body {
+  backdrop-filter: saturate(1.8) blur(var(--frost-blur));
+}
+
+@keyframes fadeInUp {
+  from {
+    opacity: 0;
+    transform: translateY(8px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
 }
 
 /* Base styles */
@@ -1127,6 +1187,10 @@ p {
 
 .content-view.hidden {
   display: none;
+}
+
+[data-theme="clear"] .content-view {
+  animation: fadeInUp var(--duration-normal) var(--ease-standard);
 }
 
 /* Page Header */

--- a/test_nexia_app.html
+++ b/test_nexia_app.html
@@ -40,7 +40,11 @@
     <div id="calendarGrid"></div>
     <input id="usernameInput" />
     <select id="languageSelect"><option value="ja">JA</option></select>
-    <select id="themeSelect"><option value="light">Light</option></select>
+    <select id="themeSelect">
+        <option value="light">Light</option>
+        <option value="dark">Dark</option>
+        <option value="clear">Clear</option>
+    </select>
     <div id="timerDisplay"></div>
     <div class="content-view" id="editorView"></div>
     <div class="content-view hidden" id="tableView"></div>


### PR DESCRIPTION
## Summary
- introduce iOS/Vision OS inspired clear design
- cycle light, dark, and clear themes via theme toggle
- animate clear theme components with fade-in motion
- update translations about the new clear design

## Testing
- `node run_nexia_tests.js` *(fails: Cannot find module 'puppeteer')*

------
https://chatgpt.com/codex/tasks/task_e_6846da28fc608324a5be4c0a3501ec7e